### PR TITLE
WIP: include new ArgumentParser.subcommand_used method

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1213,6 +1213,19 @@ public:
     }
   }
 
+  /* Flush this parser, and all subsequent subparsers, leaving
+  * 'clean slate' state of arguments.
+  */
+  void flush_args() {
+    for (auto it = std::begin(m_subparser_map); it != std::end(m_subparser_map); ++it) {
+      // invoke flush on subparser
+      it->second->get().flush_args();
+    }
+
+    m_subparser_used = std::map<std::string_view, bool>();
+    m_is_parsed = false;
+  }
+
   /* Call parse_known_args_internal - which does all the work
    * Then, validate the parsed arguments
    * This variant is used mainly for testing

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -1288,6 +1288,12 @@ public:
     return is_subcommand_used(subparser.m_program_name);
   }
 
+  /* Getter that returns the name of the subcommand used.
+  */
+  auto subcommand_used() const {
+    return m_subparser_used.begin()->first;
+  }
+
   /* Indexing operator. Return a reference to an Argument object
    * Used in conjuction with Argument.operator== e.g., parser["foo"] == true
    * @throws std::logic_error in case of an invalid argument name

--- a/test/test_subparsers.cpp
+++ b/test/test_subparsers.cpp
@@ -237,3 +237,34 @@ TEST_CASE("Check is_subcommand_used after parse" * test_suite("subparsers")) {
     REQUIRE(program.is_subcommand_used(command_2) == false);
   }
 }
+
+TEST_CASE("Check subcommand_used after parse" * test_suite("subparsers")) {
+  argparse::ArgumentParser command_1("add");
+
+  argparse::ArgumentParser command_2("clean");
+  command_2.add_argument("--fullclean")
+        .default_value(false)
+        .implicit_value(true);
+
+  argparse::ArgumentParser program("test");
+  program.add_subparser(command_1);
+  program.add_subparser(command_2);
+
+  SUBCASE("command 1") {
+    program.parse_args({"test", "add"});
+    REQUIRE(program.subcommand_used() == "add");
+    REQUIRE(program.subcommand_used() != "clean");
+  }
+
+  SUBCASE("command 2") {
+    program.parse_args({"test", "clean"});
+    REQUIRE(program.subcommand_used() == "clean");
+    REQUIRE(program.subcommand_used() != "add");
+  }
+
+  SUBCASE("none") {
+    program.parse_args({"test"});
+    REQUIRE(program.subcommand_used() != "add");
+    REQUIRE(program.subcommand_used() != "clean");
+  }
+}

--- a/test/test_subparsers.cpp
+++ b/test/test_subparsers.cpp
@@ -251,18 +251,21 @@ TEST_CASE("Check subcommand_used after parse" * test_suite("subparsers")) {
   program.add_subparser(command_2);
 
   SUBCASE("command 1") {
+    program.flush_args();
     program.parse_args({"test", "add"});
     REQUIRE(program.subcommand_used() == "add");
     REQUIRE(program.subcommand_used() != "clean");
   }
 
   SUBCASE("command 2") {
+    program.flush_args();
     program.parse_args({"test", "clean"});
     REQUIRE(program.subcommand_used() == "clean");
     REQUIRE(program.subcommand_used() != "add");
   }
 
   SUBCASE("none") {
+    program.flush_args();
     program.parse_args({"test"});
     REQUIRE(program.subcommand_used() != "add");
     REQUIRE(program.subcommand_used() != "clean");


### PR DESCRIPTION
Proposing an additional method for subparser-- uh... parsing.
This is probably coming from ignorance as a beginning C++ programmer, but sanity would be more sated from being able to 'get' the last subcommand used instead of guessing/looping through possible directives.